### PR TITLE
WEB-3482: Export encoder(s)

### DIFF
--- a/projects/lusid-sdk-angular13/src/lib/index.ts
+++ b/projects/lusid-sdk-angular13/src/lib/index.ts
@@ -1,1 +1,2 @@
 export * from './.generated'
+export * from './.generated/encoder'


### PR DESCRIPTION
* specifically CustomHttpParameterCodec, which is used by the LUSID website